### PR TITLE
PHP 7.* support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
  
 php:
-  - 5.3.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - nightly
  
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
  
 before_script:

--- a/src/common/HttpUtil.php
+++ b/src/common/HttpUtil.php
@@ -79,7 +79,7 @@ class HttpUtil {
      * @param int $status
      * @return null|string
      */
-    public function status_message($status) {
+    public static function status_message($status) {
         if (array_key_exists($status, self::$messages)) {
             return self::$messages[$status];
         }


### PR DESCRIPTION
Support for PHP 7.0 and 7.1:
- Fixes #3 that was allows in previous PHP versions.
- Adds PHP 7.0, 7.1 and nightly for testing by Travis CI.